### PR TITLE
[SECURITY] CVE-2019-16303 - JHipster Vulnerability Fix - Use CSPRNG in RandomUtil

### DIFF
--- a/flute/src/main/java/com/nomura/wmd/service/util/RandomUtil.java
+++ b/flute/src/main/java/com/nomura/wmd/service/util/RandomUtil.java
@@ -2,14 +2,25 @@ package com.nomura.wmd.service.util;
 
 import org.apache.commons.lang3.RandomStringUtils;
 
+import java.security.SecureRandom;
+
 /**
  * Utility class for generating random Strings.
  */
 public final class RandomUtil {
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private static final int DEF_COUNT = 20;
 
+    static {
+        SECURE_RANDOM.nextBytes(new byte[64]);
+    }
+
     private RandomUtil() {
+    }
+
+    private static String generateRandomAlphanumericString() {
+        return RandomStringUtils.random(DEF_COUNT, 0, 0, true, true, null, SECURE_RANDOM);
     }
 
     /**
@@ -18,7 +29,7 @@ public final class RandomUtil {
      * @return the generated password
      */
     public static String generatePassword() {
-        return RandomStringUtils.randomAlphanumeric(DEF_COUNT);
+        return generateRandomAlphanumericString();
     }
 
     /**
@@ -27,7 +38,7 @@ public final class RandomUtil {
      * @return the generated activation key
      */
     public static String generateActivationKey() {
-        return RandomStringUtils.randomNumeric(DEF_COUNT);
+        return generateRandomAlphanumericString();
     }
 
     /**
@@ -36,6 +47,6 @@ public final class RandomUtil {
     * @return the generated reset key
     */
     public static String generateResetKey() {
-        return RandomStringUtils.randomNumeric(DEF_COUNT);
+        return generateRandomAlphanumericString();
     }
 }


### PR DESCRIPTION
---

This is a security fix for a  vulnerability in your [JHipster](https://www.jhipster.tech/) generated `RandomUtil.java` file(s).

## Technical Impact

Using one password reset token from your app combined with the POC below, an attacker can determine all future password reset tokens to be generated by this server. This allows an attacker to pick and choose what account they would like to takeover by sending account password reset requests for targeted accounts.

## Tell Me More!

A version of JHipster Generator that was vulnerable to [CVE-2019-16303](https://github.com/jhipster/jhipster-kotlin/security/advisories/GHSA-j3rh-8vwq-wh84) was used to generate this project.
This version of JHipster generated code using an insecure source of randomness in security sensitive locations.

This class of vulnerability is better known as [CWE-338: Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)](https://cwe.mitre.org/data/definitions/338.html).

This vulnerability has a CVSS v3.0 Base Score of [9.8/10](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?name=CVE-2019-16303&vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.1&source=NIST).

[POC code](http://web.archive.org/web/20191126104359/https://medium.com/@alex91ar/the-java-soothsayer-a-practical-application-for-insecure-randomness-c67b0cd148cd) has existed since March 3rd, 2018 for taking one RNG value generated by `RandomStringUtils` and reversing it to generate all of the past/future RNG values.

This contribution is a part of a submission to the [GitHub Security Lab](https://securitylab.github.com/) Bug Bounty program.

## Detecting this and Future Vulnerabilities

[LGTM.com](https://lgtm.com) was used to automatically detect this vulnerability using a custom CodeQL query.

As of September 2019 LGTM.com and Semmle are [officially a part of GitHub](https://github.blog/2019-09-18-github-welcomes-semmle/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [LGTM App](https://github.com/marketplace/lgtm).

I'm not an employee of GitHub nor of Semmle, I'm simply a user of [LGTM.com](https://lgtm.com) and an open-source security researcher.

## Source

Yes, this contribution was automatically generated, however, the code to generate this PR was lovingly hand crafted to bring this security fix to your repository.

The source code that generated and submitted this PR can be found here:
[JLLeitschuh/bulk-security-pr-generator](https://github.com/JLLeitschuh/bulk-security-pr-generator)

The fix was generated for each vulnerable file, preserving the original style of the file, by the [Rewrite project](https://github.com/openrewrite/rewrite). See the specific code for this fix [here](https://github.com/moderneinc/jhipster-cwe-338).

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/bulk-security-pr-generator
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin 
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Tracking

All PR's generated as part of this fix are tracked here: 
https://github.com/JLLeitschuh/bulk-security-pr-generator/issues/5